### PR TITLE
Minimal client functionality for logging daemon

### DIFF
--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -1,223 +1,11 @@
 import asyncio
 import collections
-import logging
 import typing
 from typing import Optional
 
 from .. import constants, log, protocol, structs
 from ..constants import AdsTransmissionMode, AmsPort
 from . import utils
-
-logger = logging.getLogger(__name__)
-
-
-class AsyncioClient:
-    client: protocol.Client
-    log: log.ComposableLogAdapter
-    reader: asyncio.StreamReader
-    writer: asyncio.StreamWriter
-
-    def __init__(
-            self,
-            server_host: typing.Tuple[str, int],
-            server_net_id: str,
-            client_net_id: str,
-            reconnect_rate=10,
-            ):
-        self.client = protocol.Client(
-            server_host=server_host,
-            server_net_id=server_net_id,
-            client_net_id=client_net_id,
-            address=('0.0.0.0', 0)
-        )
-        self.log = self.client.log
-        self._queue = utils.AsyncioQueue()
-        self._handle_index = 0
-        self._tasks = utils._TaskHandler()
-        self._tasks.create(self._connect())
-        self._response_handlers = collections.defaultdict(list)
-        self.user_callback_executor = utils.CallbackExecutor(self.log)
-        self.reconnect_rate = reconnect_rate
-
-    async def _connect(self):
-        self._tasks.create(self._request_queue_loop())
-        while True:
-            self.log.debug('Connecting...')
-            self.reader, self.writer = await asyncio.open_connection(
-                host=self.client.server_host[0],
-                port=self.client.server_host[1],
-            )
-            self.log.debug('Connected')
-
-            await self._receive_loop()
-            self.log.debug('Disconnected')
-            if self.reconnect_rate is not None:
-                self.log.debug(
-                    'Reconnecting in %d seconds...', self.reconnect_rate
-                )
-                await asyncio.sleep(self.reconnect_rate)
-            else:
-                self.log.debug('Not reconnecting.')
-
-    async def send(
-            self, *items,
-            ads_error: constants.AdsError = constants.AdsError.NOERR,
-            port: Optional[AmsPort] = None,
-            response_handler: Optional[typing.Coroutine] = None,
-    ):
-        """
-        Package and send items over the wire.
-
-        Parameters
-        ----------
-        *items :
-            Items to send.
-
-        port : AmsPort, optional
-            Port to request notifications from.  Defaults to the current target
-            port.
-
-        Returns
-        -------
-        invoke_id : int
-            Returns the invocation ID associated with the request.
-        """
-        invoke_id, bytes_to_send = self.client.request_to_wire(
-            *items, ads_error=ads_error,
-            port=port or self.client.their_port
-        )
-        if response_handler is not None:
-            self._response_handlers[invoke_id].append(response_handler)
-
-        self.writer.write(bytes_to_send)
-        await self.writer.drain()
-        return invoke_id
-
-    async def _receive_loop(self):
-        while True:
-            data = await self.reader.read(1024)
-            if not len(data):
-                self.client.disconnected()
-                break
-
-            for header, item in self.client.received_data(data):
-                await self._handle_command(header, item)
-
-    async def _handle_command(self, header: structs.AoEHeader, item):
-        invoke_id_handlers = self._response_handlers.get(header.invoke_id, [])
-        try:
-            _ = self.client.handle_command(header, item)
-        except protocol.MissingHandlerError:
-            if not invoke_id_handlers:
-                self.log.debug('No registered handler for %s %s', header, item)
-        except Exception:
-            self.log.exception('handle_command failed with unknown error')
-
-        for handler in invoke_id_handlers:
-            try:
-                await handler(header, item)
-            except Exception:
-                self.log.exception('handle_command failed with unknown error')
-
-        # if response is None:
-        #     return
-
-        # if isinstance(response, protocol.AsynchronousResponse):
-        #     response.requester = self
-        #     await self._queue.async_put(response)
-        # elif isinstance(response, protocol.ErrorResponse):
-        #     self.log.error('Error response: %r', response)
-
-        #     err_cls = structs.get_struct_by_command(
-        #         response.request.command_id,
-        #         request=False)  # type: typing.Type[structs._AdsStructBase]
-        #     err_response = err_cls(result=response.code)
-        #     await self.send_response(err_response,
-        #                              request_header=header,
-        #                              )
-        # else:
-        #     await self.send_response(*response, request_header=header)
-
-    async def _request_queue_loop(self):
-        ...
-        # server = self.server
-        # while server.running:
-        #     request = await self._queue.async_get()
-        #     self.log.debug('Handling %s', request)
-
-        #     index_group = request.command.index_group
-        #     if index_group == constants.AdsIndexGroup.SYM_HNDBYNAME:
-        #         ...
-        #     # self._tasks.create()
-
-    def enable_log_system(self, length=255):
-        return self.add_notification_by_index(
-            index_group=1,
-            index_offset=65535,
-            length=length,
-            port=AmsPort.LOGGER,
-        )
-
-    def add_notification_by_index(
-        self,
-        index_group: int,
-        index_offset: int,
-        length: int,
-        mode: AdsTransmissionMode = AdsTransmissionMode.SERVERCYCLE,
-        max_delay: int = 1,
-        cycle_time: int = 100,
-        port: Optional[AmsPort] = None,
-    ):
-        """
-        Add an advanced notification by way of index group/offset.
-
-        Parameters
-        -----------
-        index_group : int
-            Contains the index group number of the requested ADS service.
-
-        index_offset : int
-            Contains the index offset number of the requested ADS service.
-
-        length : int
-            Max length.
-
-        mode : AdsTransmissionMode
-            Specifies if the event should be fired cyclically or only if the
-            variable has changed.
-
-        max_delay : int
-            The event is fired at *latest* when this time has elapsed. [ms]
-
-        cycle_time : int
-            The ADS server checks whether the variable has changed after this
-            time interval. [ms]
-
-        port : AmsPort, optional
-            Port to request notifications from.  Defaults to the current target
-            port.
-        """
-        # TODO: reuse one if it already exists
-        # TODO: notifications should be tracked on the 'protocol' level
-        return Notification(
-            owner=self, user_callback_executor=self.user_callback_executor,
-            command=self.client.add_notification_by_index(
-                index_group=index_group,
-                index_offset=index_offset,
-                length=length,
-                mode=mode,
-                max_delay=max_delay,
-                cycle_time=cycle_time,
-            ),
-            port=port,
-        )
-
-    async def prune_unknown_notifications(self):
-        """Prune all unknown notification IDs by unregistering each of them."""
-        for source, handle in self.client.unknown_notifications:
-            _, port = source
-            await self.send(self.client.remove_notification(handle),
-                            port=port)
 
 
 class Notification(utils.CallbackHandler):
@@ -380,6 +168,233 @@ class Notification(utils.CallbackHandler):
                 self.needs_reactivation = False
 
 
+class AsyncioClient:
+    client: protocol.Client
+    log: log.ComposableLogAdapter
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+
+    def __init__(
+            self,
+            server_host: typing.Tuple[str, int],
+            server_net_id: str,
+            client_net_id: Optional[str] = None,  # can be determined later
+            reconnect_rate=10,
+            ):
+        self.client = protocol.Client(
+            server_host=server_host,
+            server_net_id=server_net_id,
+            client_net_id=client_net_id,
+            address=('0.0.0.0', 0)
+        )
+        self.log = self.client.log
+        self._queue = utils.AsyncioQueue()
+        self._handle_index = 0
+        self._tasks = utils._TaskHandler()
+        self._tasks.create(self._connect())
+        self._response_handlers = collections.defaultdict(list)
+        self.user_callback_executor = utils.CallbackExecutor(self.log)
+        self.reconnect_rate = reconnect_rate
+        self._connect_event = asyncio.Event()
+
+    async def wait_for_connection(self):
+        """Block until connected."""
+        await self._connect_event.wait()
+
+    async def _connect(self):
+        self._tasks.create(self._request_queue_loop())
+        while True:
+            self.log.debug('Connecting...')
+            try:
+                self.reader, self.writer = await asyncio.open_connection(
+                    host=self.client.server_host[0],
+                    port=self.client.server_host[1],
+                )
+            except OSError:
+                self.log.exception('Failed to connect')
+            else:
+                await self._connected_loop()
+
+            if self.reconnect_rate is not None:
+                self.log.debug(
+                    'Reconnecting in %d seconds...', self.reconnect_rate
+                )
+                await asyncio.sleep(self.reconnect_rate)
+            else:
+                self.log.debug('Not reconnecting.')
+
+    async def send(
+            self, *items,
+            ads_error: constants.AdsError = constants.AdsError.NOERR,
+            port: Optional[AmsPort] = None,
+            response_handler: Optional[typing.Coroutine] = None,
+    ):
+        """
+        Package and send items over the wire.
+
+        Parameters
+        ----------
+        *items :
+            Items to send.
+
+        port : AmsPort, optional
+            Port to request notifications from.  Defaults to the current target
+            port.
+
+        Returns
+        -------
+        invoke_id : int
+            Returns the invocation ID associated with the request.
+        """
+        invoke_id, bytes_to_send = self.client.request_to_wire(
+            *items, ads_error=ads_error,
+            port=port or self.client.their_port
+        )
+        if response_handler is not None:
+            self._response_handlers[invoke_id].append(response_handler)
+
+        self.writer.write(bytes_to_send)
+        await self.writer.drain()
+        return invoke_id
+
+    async def _connected_loop(self):
+        self.log.debug('Connected')
+
+        if self.client.client_net_id is None:
+            our_ip, *_ = self.writer.get_extra_info('socket')
+            self.client.client_net_id = f'{our_ip}.1.1'
+            self.log.debug('Auto-configuring local net ID: %s',
+                           self.client.client_net_id)
+
+        self._connect_event.set()
+        while True:
+            data = await self.reader.read(1024)
+            if not len(data):
+                self.client.disconnected()
+                self.log.debug('Disconnected')
+                self._connect_event.clear()
+                break
+
+            for header, item in self.client.received_data(data):
+                await self._handle_command(header, item)
+
+    async def _handle_command(self, header: structs.AoEHeader, item):
+        invoke_id_handlers = self._response_handlers.get(header.invoke_id, [])
+        try:
+            _ = self.client.handle_command(header, item)
+        except protocol.MissingHandlerError:
+            if not invoke_id_handlers:
+                self.log.debug('No registered handler for %s %s', header, item)
+        except Exception:
+            self.log.exception('handle_command failed with unknown error')
+
+        for handler in invoke_id_handlers:
+            try:
+                await handler(header, item)
+            except Exception:
+                self.log.exception('handle_command failed with unknown error')
+
+        # if response is None:
+        #     return
+
+        # if isinstance(response, protocol.AsynchronousResponse):
+        #     response.requester = self
+        #     await self._queue.async_put(response)
+        # elif isinstance(response, protocol.ErrorResponse):
+        #     self.log.error('Error response: %r', response)
+
+        #     err_cls = structs.get_struct_by_command(
+        #         response.request.command_id,
+        #         request=False)  # type: typing.Type[structs._AdsStructBase]
+        #     err_response = err_cls(result=response.code)
+        #     await self.send_response(err_response,
+        #                              request_header=header,
+        #                              )
+        # else:
+        #     await self.send_response(*response, request_header=header)
+
+    async def _request_queue_loop(self):
+        ...
+        # server = self.server
+        # while server.running:
+        #     request = await self._queue.async_get()
+        #     self.log.debug('Handling %s', request)
+
+        #     index_group = request.command.index_group
+        #     if index_group == constants.AdsIndexGroup.SYM_HNDBYNAME:
+        #         ...
+        #     # self._tasks.create()
+
+    def enable_log_system(self, length=255):
+        return self.add_notification_by_index(
+            index_group=1,
+            index_offset=65535,
+            length=length,
+            port=AmsPort.LOGGER,
+        )
+
+    def add_notification_by_index(
+        self,
+        index_group: int,
+        index_offset: int,
+        length: int,
+        mode: AdsTransmissionMode = AdsTransmissionMode.SERVERCYCLE,
+        max_delay: int = 1,
+        cycle_time: int = 100,
+        port: Optional[AmsPort] = None,
+    ):
+        """
+        Add an advanced notification by way of index group/offset.
+
+        Parameters
+        -----------
+        index_group : int
+            Contains the index group number of the requested ADS service.
+
+        index_offset : int
+            Contains the index offset number of the requested ADS service.
+
+        length : int
+            Max length.
+
+        mode : AdsTransmissionMode
+            Specifies if the event should be fired cyclically or only if the
+            variable has changed.
+
+        max_delay : int
+            The event is fired at *latest* when this time has elapsed. [ms]
+
+        cycle_time : int
+            The ADS server checks whether the variable has changed after this
+            time interval. [ms]
+
+        port : AmsPort, optional
+            Port to request notifications from.  Defaults to the current target
+            port.
+        """
+        # TODO: reuse one if it already exists
+        # TODO: notifications should be tracked on the 'protocol' level
+        return Notification(
+            owner=self, user_callback_executor=self.user_callback_executor,
+            command=self.client.add_notification_by_index(
+                index_group=index_group,
+                index_offset=index_offset,
+                length=length,
+                mode=mode,
+                max_delay=max_delay,
+                cycle_time=cycle_time,
+            ),
+            port=port,
+        )
+
+    async def prune_unknown_notifications(self):
+        """Prune all unknown notification IDs by unregistering each of them."""
+        for source, handle in self.client.unknown_notifications:
+            _, port = source
+            await self.send(self.client.remove_notification(handle),
+                            port=port)
+
+
 if __name__ == '__main__':
     server = None
 
@@ -388,10 +403,21 @@ if __name__ == '__main__':
                                server_net_id='172.21.148.227.1.1',
                                client_net_id='172.21.148.164.1.1',
                                )
-        await asyncio.sleep(1)  # connection event
+        await client.wait_for_connection()
+
+        # Give some time for initial notifications, and prune any stale ones
+        # from previous sessions:
+        await asyncio.sleep(1.0)
         await client.prune_unknown_notifications()
-        async for message in client.enable_log_system():
-            print('log system notification', message)
+        async for header, timestamp, sample in client.enable_log_system():
+            try:
+                message = sample.as_log_message()
+            except Exception:
+                client.log.exception('Got a bad log message sample? %s',
+                                     sample)
+                continue
+
+            client.log.info("Log message %s", message)
 
     from .. import log
     log.configure(level='DEBUG')

--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -1,0 +1,212 @@
+import asyncio
+import functools
+import logging
+import typing
+
+from .. import constants, log, protocol, structs, symbols
+from ..constants import AdsTransmissionMode, AmsPort
+from . import utils
+
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncioClient:
+    client: protocol.Client
+    log: log.ComposableLogAdapter
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+
+    def __init__(
+            self,
+            server_host: typing.Tuple[str, int],
+            server_net_id: str,
+            client_net_id: str,
+            ):
+        self.client = protocol.Client(
+            server_host=server_host,
+            server_net_id=server_net_id,
+            client_net_id=client_net_id,
+            address=('0.0.0.0', 0)
+        )
+        self.log = self.client.log
+        self._should_reconnect = True
+        self._queue = utils.AsyncioQueue()
+        self._handle_index = 0
+        self._tasks = utils._TaskHandler()
+        self._tasks.create(self._connect())
+
+    async def _connect(self):
+        while self._should_reconnect:
+            self.reader, self.writer = await asyncio.open_connection(
+                host=self.client.server_host[0],
+                port=self.client.server_host[1],
+            )
+            self.log.debug('Connected')
+
+            await self._receive_loop()
+            self.log.debug('Disconnected')
+            if self._should_reconnect:
+                self.log.debug('Reconnecting in 10 seconds...')
+                await asyncio.sleep(10)
+            else:
+                self.log.debug('Not reconnecting.')
+
+    async def send(
+            self, *items,
+            ads_error: constants.AdsError = constants.AdsError.NOERR,
+            port: Optional[AmsPort] = None,
+    ):
+        """
+        Package and send items over the wire.
+
+        Parameters
+        ----------
+        *items :
+            Items to send.
+
+        port : AmsPort, optional
+            Port to request notifications from.  Defaults to the current target
+            port.
+        """
+        bytes_to_send = self.client.request_to_wire(
+            *items, ads_error=ads_error,
+            port=port or self.client.their_port
+        )
+        self.writer.write(bytes_to_send)
+        await self.writer.drain()
+
+    # async def _receive_loop(self):
+    #     with open('ads_messages3.txt', 'rb') as f:
+    #         data = bytearray(f.read())
+
+    #     for header, item in self.client.received_data(data):
+    #         await self._handle_command(header, item)
+
+    async def _receive_loop(self):
+        self._tasks.create(self._request_queue_loop())
+        while True:
+            data = await self.reader.read(1024)
+            print('received', data)
+            if not len(data):
+                self.client.disconnected()
+                break
+
+            for header, item in self.client.received_data(data):
+                await self._handle_command(header, item)
+
+    async def _handle_command(self, header: structs.AoEHeader, item):
+        try:
+            response = self.client.handle_command(header, item)
+        except Exception:
+            logger.exception('handle_command failed with unknown error')
+            return
+
+        if response is None:
+            return
+
+        if isinstance(response, protocol.AsynchronousResponse):
+            response.requester = self
+            await self._queue.async_put(response)
+        elif isinstance(response, protocol.ErrorResponse):
+            self.log.error('Error response: %r', response)
+
+            err_cls = structs.get_struct_by_command(
+                response.request.command_id,
+                request=False)  # type: typing.Type[structs._AdsStructBase]
+            err_response = err_cls(result=response.code)
+            await self.send_response(err_response,
+                                     request_header=header,
+                                     )
+        else:
+            await self.send_response(*response, request_header=header)
+
+    async def _request_queue_loop(self):
+        ...
+        # server = self.server
+        # while server.running:
+        #     request = await self._queue.async_get()
+        #     self.log.debug('Handling %s', request)
+
+        #     index_group = request.command.index_group
+        #     if index_group == constants.AdsIndexGroup.SYM_HNDBYNAME:
+        #         ...
+        #     # self._tasks.create()
+
+    async def enable_log_system(self, length=255):
+        return await self.add_notification_by_index(
+            index_group=1,
+            index_offset=65535,
+            length=length,
+            port=AmsPort.LOGGER,
+        )
+
+    async def add_notification_by_index(
+        self,
+        index_group: int,
+        index_offset: int,
+        length: int,
+        mode: AdsTransmissionMode = AdsTransmissionMode.SERVERCYCLE,
+        max_delay: int = 1,
+        cycle_time: int = 100,
+        port: Optional[AmsPort] = None,
+    ):
+        """
+        Add an advanced notification by way of index group/offset.
+
+        Parameters
+        -----------
+        index_group : int
+            Contains the index group number of the requested ADS service.
+
+        index_offset : int
+            Contains the index offset number of the requested ADS service.
+
+        length : int
+            Max length.
+
+        mode : AdsTransmissionMode
+            Specifies if the event should be fired cyclically or only if the
+            variable has changed.
+
+        max_delay : int
+            The event is fired at *latest* when this time has elapsed. [ms]
+
+        cycle_time : int
+            The ADS server checks whether the variable has changed after this
+            time interval. [ms]
+
+        port : AmsPort, optional
+            Port to request notifications from.  Defaults to the current target
+            port.
+        """
+        await self.send(
+            self.client.add_notification_by_index(
+                index_group=index_group,
+                index_offset=index_offset,
+                length=length,
+                mode=mode,
+                max_delay=max_delay,
+                cycle_time=cycle_time,
+            ),
+            port=port,
+        )
+
+
+if __name__ == '__main__':
+    server = None
+
+    async def test():
+        client = AsyncioClient(server_host=('localhost', 48898),
+                               server_net_id='172.21.148.227.1.1',
+                               client_net_id='172.21.148.164.1.1',
+                               )
+        await asyncio.sleep(1)  # connection event
+        await client.enable_log_system()
+        await asyncio.sleep(100)
+
+    from .. import log
+    log.configure(level='DEBUG')
+
+    asyncio.run(test(), debug=True)

--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -47,7 +47,7 @@ class Notification(utils.CallbackHandler):
             )
 
     def process(self, header, timestamp, sample):
-        self.log.debug("Notification update [%d]: %s", timestamp, sample)
+        self.log.debug("Notification update [%s]: %s", timestamp, sample)
         notification = dict(header=header, timestamp=timestamp, sample=sample)
         super().process(self, **notification)
         self.most_recent_notification = notification
@@ -396,8 +396,6 @@ class AsyncioClient:
 
 
 if __name__ == '__main__':
-    server = None
-
     async def test():
         client = AsyncioClient(server_host=('localhost', 48898),
                                server_net_id='172.21.148.227.1.1',

--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -407,7 +407,7 @@ if __name__ == '__main__':
         # from previous sessions:
         await asyncio.sleep(1.0)
         await client.prune_unknown_notifications()
-        async for header, timestamp, sample in client.enable_log_system():
+        async for header, _, sample in client.enable_log_system():
             try:
                 message = sample.as_log_message()
             except Exception:

--- a/ads_async/asyncio/utils.py
+++ b/ads_async/asyncio/utils.py
@@ -92,7 +92,6 @@ class CallbackExecutor:
             callback, args, kwargs = await self.callbacks.async_get()
             if inspect.iscoroutinefunction(callback):
                 try:
-                    print(callback, args, kwargs)
                     await callback(*args, **kwargs)
                 except Exception:
                     self.log.exception('Callback failure')

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -1048,5 +1048,19 @@ class Client(ConnectionBase):
         """
         return structs.AdsDeviceInfoRequest()
 
+    def get_symbol_info_by_name(
+        self,
+        name: str,
+    ) -> structs.AdsReadWriteRequest:
+        """
+        Get symbol information by name.
+
+        Parameters
+        -----------
+        name : str
+            The symbol name.
+        """
+        return structs.AdsReadWriteRequest.create_info_by_name_request(name)
+
 
 Client._handlers = dict(_aggregate_handlers(Client))

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -95,10 +95,10 @@ def from_wire(
             except KeyError:
                 cmd = view[:aoe_header.length]
             else:
-                # if hasattr(cmd_cls, 'from_buffer_extended'):
+                # if hasattr(cmd_cls, 'deserialize'):
                 # TODO: can't call super.from_buffer in a subclass
                 # classmethod?
-                cmd = cmd_cls.from_buffer_extended(view)
+                cmd = cmd_cls.deserialize(view)
 
             item = (aoe_header, cmd)
 

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -795,7 +795,7 @@ class Client(ConnectionBase):
     def __init__(self,
                  server_host: typing.Tuple[str, int],
                  server_net_id: str,
-                 client_net_id: str,
+                 client_net_id: typing.Optional[str],
                  address: typing.Tuple[str, int],
                  ):
         self.server_net_id = server_net_id

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -1094,5 +1094,27 @@ class Client(ConnectionBase):
             0,
         )
 
+    def get_value_by_handle(
+        self,
+        handle: int,
+        size: int,
+    ) -> structs.AdsReadRequest:
+        """
+        Get symbol value by handle.
+
+        Parameters
+        -----------
+        handle : int
+            The handle identifier.
+
+        size : int
+            The size, in bytes, to read.
+        """
+        return structs.AdsReadRequest(
+            constants.AdsIndexGroup.SYM_VALBYHND,
+            handle,
+            size,
+        )
+
 
 Client._handlers = dict(_aggregate_handlers(Client))

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -1037,5 +1037,16 @@ class Client(ConnectionBase):
             handle=handle
         )
 
+    def get_device_information(self):
+        """
+        Remove a notification given its handle.
+
+        Parameters
+        -----------
+        handle : int
+            The notification handle.
+        """
+        return structs.AdsDeviceInfoRequest()
+
 
 Client._handlers = dict(_aggregate_handlers(Client))

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -1062,5 +1062,37 @@ class Client(ConnectionBase):
         """
         return structs.AdsReadWriteRequest.create_info_by_name_request(name)
 
+    def get_symbol_handle_by_name(
+        self,
+        name: str,
+    ) -> structs.AdsReadWriteRequest:
+        """
+        Get symbol handle by name.
+
+        Parameters
+        -----------
+        name : str
+            The symbol name.
+        """
+        return structs.AdsReadWriteRequest.create_handle_by_name_request(name)
+
+    def release_handle(
+        self,
+        handle: int,
+    ) -> structs.AdsWriteRequest:
+        """
+        Release a handle by id.
+
+        Parameters
+        -----------
+        handle : int
+            The handle identifier.
+        """
+        return structs.AdsWriteRequest(
+            constants.AdsIndexGroup.SYM_RELEASEHND,
+            handle,
+            0,
+        )
+
 
 Client._handlers = dict(_aggregate_handlers(Client))

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -473,7 +473,7 @@ class AdsNotificationLogMessage(_AdsStructBase):
         ('ams_port', ctypes.c_uint32),
         ('_sender_name', ctypes.c_ubyte * 16),
         ('message_length', ctypes.c_uint32),
-        # message
+        # (message here)
     ]
 
     _payload_fields = [

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -358,6 +358,9 @@ class AmsAddr(_AdsStructBase):
             return f'{self.net_id}:{self.port.value}({self.port.name})'
         return f'{self.net_id}:{self.port}'
 
+    def __iter__(self):
+        return iter((repr(self.net_id), self.port))
+
 
 class AdsVersion(_AdsStructBase):
     """Contains the version number, revision number and build number."""
@@ -534,7 +537,10 @@ class AdsNotificationSample(_AdsStructBase):
     _dict_mapping = {'_data_start': 'data'}
 
     def as_log_message(self) -> AdsNotificationLogMessage:
-        return AdsNotificationLogMessage.from_buffer_extended(bytearray(self.data))
+        """Try to convert the raw message to a log message."""
+        return AdsNotificationLogMessage.from_buffer_extended(
+            bytearray(self.data)
+        )
 
 
 class AdsNotificationStampHeader(_AdsStructBase):
@@ -562,7 +568,7 @@ class AdsNotificationStampHeader(_AdsStructBase):
         new_struct.samples = []
         for idx in range(new_struct.num_samples):
             sample = AdsNotificationSample.from_buffer_extended(payload_buf)
-            print('\n' * 3, sample.as_log_message())
+            # print('\n' * 3, sample.as_log_message())
             new_struct.samples.append(sample)
             consumed = (
                 ctypes.sizeof(AdsNotificationSample) + sample.sample_size
@@ -571,12 +577,6 @@ class AdsNotificationStampHeader(_AdsStructBase):
             payload_buf = payload_buf[consumed:]
 
         return new_struct
-
-    # def __repr__(self):
-    #     return (
-    #         f"<{self.__class__.__name__} timestamp={self.timestamp} "
-    #         f"num_samples={self.num_samples} samples={self.samples}>"
-    #     )
 
 
 @use_for_request(constants.AdsCommandId.DEVICE_NOTIFICATION)
@@ -602,17 +602,13 @@ class AdsNotificationStream(_AdsStructBase):
 
         new_struct.stamps = []
         for stamp in range(new_struct.num_stamps):
-            stamp = AdsNotificationStampHeader.from_buffer_extended(payload_buf)
+            stamp = AdsNotificationStampHeader.from_buffer_extended(
+                payload_buf
+            )
             new_struct.stamps.append(stamp)
             payload_buf = payload_buf[stamp.byte_size:]
 
         return new_struct
-
-    # def __repr__(self):
-    #     return (
-    #         f"<{self.__class__.__name__} length={self.length} "
-    #         f"num_stamps={self.num_stamps} stamps={self.stamps}>"
-    #     )
 
 
 class AdsSymbolEntry(_AdsStructBase):

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -28,14 +28,14 @@ def _use_for(key: str, command_id: constants.AdsCommandId,
     return cls
 
 
-def use_for_response(command_id: constants.AdsCommandId):
+def use_for_response(command_id: constants.AdsCommandId) -> T_AdsStructure:
     """
     Decorator marking a class to be used for a specific AdsCommand response.
     """
     return functools.partial(_use_for, 'response', command_id)
 
 
-def use_for_request(command_id: constants.AdsCommandId):
+def use_for_request(command_id: constants.AdsCommandId) -> T_AdsStructure:
     """
     Decorator marking a class to be used for a specific AdsCommand request.
     """

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -376,6 +376,11 @@ class AdsVersion(_AdsStructBase):
     ]
 
 
+@use_for_request(constants.AdsCommandId.READ_DEVICE_INFO)
+class AdsDeviceInfoRequest(_AdsStructBase):
+    _fields_ = []
+
+
 @use_for_response(constants.AdsCommandId.READ_DEVICE_INFO)
 class AdsDeviceInfo(AdsVersion):
     """Contains the version number, revision number and build number."""

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -537,7 +537,7 @@ class AdsNotificationSample(_AdsStructBase):
         return AdsNotificationLogMessage.from_buffer_extended(bytearray(self.data))
 
 
-class AdsStampHeader(_AdsStructBase):
+class AdsNotificationStampHeader(_AdsStructBase):
     _fields_ = [
         # Contains a 64-bit value representing the number of 100-nanosecond
         # intervals since January 1, 1601 (UTC).
@@ -602,7 +602,7 @@ class AdsNotificationStream(_AdsStructBase):
 
         new_struct.stamps = []
         for stamp in range(new_struct.num_stamps):
-            stamp = AdsStampHeader.from_buffer_extended(payload_buf)
+            stamp = AdsNotificationStampHeader.from_buffer_extended(payload_buf)
             new_struct.stamps.append(stamp)
             payload_buf = payload_buf[stamp.byte_size:]
 

--- a/ads_async/symbols.py
+++ b/ads_async/symbols.py
@@ -68,6 +68,7 @@ class OffsetSize:
 
 
 class Symbol:
+    """**Server** Symbol."""
     name: str
     data_type: AdsDataType
     data_area: 'DataArea'

--- a/ads_async/utils.py
+++ b/ads_async/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import threading
 
 
@@ -30,3 +31,13 @@ class ThreadsafeCounter:
 
             self.value = value
             return self.value
+
+
+UNIX_EPOCH_START = 116444736000000000  # January 1, 1970
+
+
+def get_datetime_from_timestamp(timestamp: int) -> datetime.datetime:
+    """Get a datetime.datetime instance from a TwinCAT timestamp."""
+    return datetime.datetime.utcfromtimestamp(
+        (timestamp - UNIX_EPOCH_START) * 1e-7
+    )


### PR DESCRIPTION
Enables log notifications by using a specific group/offset and targeting the AMS LOGGER port.

Test code works to add and clean up notifications on a machine with an already-configured route (plc-tst-proto6 tunneled through SSH)

* This exposes a lot of ugliness and lack of foresight in the "protocol" level code - it was thoroughly based around the test server implementation, without leaving much room for a client
* Next will be to generalize and move over some functionality to https://github.com/pcdshub/ads-log-daemon
* Undocumented notification structure (and especially that of the log messages); determined partly by playing around and then fleshed out with the example details from Beckhoff. Still one element (presumably status code or error level) that I haven't been able to decode just yet.
 
Full client and API-thrashing-for-cleanup may come at a time when there is actually free time to spend on side projects. But for the most part, this should serve its role in the logging daemon well enough with perhaps a few more tweaks.