### PR TITLE
ENH: client task name helper

### DIFF
--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -1,7 +1,6 @@
 import asyncio
 import collections
 import ctypes
-import json
 import typing
 from typing import Optional
 
@@ -327,7 +326,7 @@ class AsyncioClient:
             server_host: typing.Tuple[str, int],
             server_net_id: Optional[str] = None,
             client_net_id: Optional[str] = None,  # can be determined later
-            reconnect_rate : Optional[int] = 10,
+            reconnect_rate: Optional[int] = 10,
             ):
         if server_net_id is None:
             server_net_id = f'{server_host[0]}.1.1'
@@ -727,79 +726,3 @@ class AsyncioClient:
             _, port = source
             await self.send(self.client.remove_notification(handle),
                             port=port)
-
-
-def to_logstash(header: structs.AoEHeader,
-                message: structs.AdsNotificationLogMessage) -> dict:
-    custom_json = {
-        "port_name": message.sender_name.decode('ascii'),
-        "ams_port": message.ams_port,
-        "source": repr(header.source),
-        "identifier": message.unknown,
-    }
-
-    # From:
-    # AdsNotificationLogMessage(timestamp=datetime.datetime,
-    #                           unknown=84, ams_port=500,
-    #                           sender_name=b'TCNC',
-    #                           message_length=114, message=b'\'Axis
-    #                           1\' (Axis-ID: 1): The axis needs the
-    #                           "Feed Forward Permission" for forward
-    #                           positioning (error-code: 0x4358) !')
-    # To:
-    # (f'{"schema":"twincat-event-0","ts":{twincat_now},"plc":"LogTest",'
-    #   '"severity":4,"id":0,'
-    #   '"event_class":"C0FFEEC0-FFEE-COFF-EECO-FFEEC0FFEEC0",'
-    #   '"msg":"Critical (Log system test.)",'
-    #   '"source":"pcds_logstash.testing.fbLogger/Debug",'
-    #   '"event_type":3,"json":"{}"}'
-    #   ),
-    return {
-        "schema": "twincat-event-0",
-        "ts": message.timestamp.timestamp(),
-        "severity": 0,  # hmm
-        "id": 0,  # hmm
-        "event_class": "C0FFEEC0-FFEE-COFF-EECO-FFEEC0FFEEC0",
-        "msg": message.message.decode('latin-1'),
-        "source": "logging.aggregator/Translator",
-        "event_type": 0,  # hmm
-        "json": json.dumps(custom_json),
-    }
-
-
-if __name__ == '__main__':
-    async def test():
-        async with AsyncioClient(
-            server_host=('localhost', 48898),
-            server_net_id='172.21.148.227.1.1',
-            client_net_id='172.21.148.164.1.1'
-        ) as client:
-            device_info = await client.get_device_information()
-            client.log.info('Device info: %s', device_info)
-            project_name = await client.get_project_name()
-            client.log.info('Project name: %s', project_name)
-            app_name = await client.get_app_name()
-            client.log.info('Application name: %s', app_name)
-            task_names = await client.get_task_names()
-            client.log.info('Task names: %s', task_names)
-
-            # Give some time for initial notifications, and prune any stale
-            # ones from previous sessions:
-            await asyncio.sleep(1.0)
-            await client.prune_unknown_notifications()
-            async for header, _, sample in client.enable_log_system():
-                try:
-                    message = sample.as_log_message()
-                except Exception:
-                    client.log.exception('Got a bad log message sample? %s',
-                                         sample)
-                    continue
-
-                client.log.info("Log message %s ==> %s", message,
-                                to_logstash(header, message))
-
-    from .. import log
-    log.configure(level='DEBUG')
-    # log.configure(level='INFO')
-
-    value = asyncio.run(test(), debug=True)

--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -40,18 +40,19 @@ class Notification(utils.CallbackHandler):
         header,
         response: structs.AoENotificationHandleResponse
     ):
-        if response.result == constants.AdsError.NOERR:
-            self.handle = response.handle
-            self.log.debug(
-                "Notification initialized (handle=%d)", self.handle
-            )
-            # TODO: unsubscribe if no listeners?
-            client = self.owner.client
-            client.handle_to_notification[response.handle] = self
-        else:
+        if response.result != constants.AdsError.NOERR:
             self.log.debug(
                 "Notification failed to initialize: %s", response.result
             )
+            return
+
+        self.handle = response.handle
+        self.log.debug(
+            "Notification initialized (handle=%d)", self.handle
+        )
+        # TODO: unsubscribe if no listeners?
+        client = self.owner.client
+        client.handle_to_notification[response.handle] = self
 
     def process(self, header, timestamp, sample):
         self.log.debug("Notification update [%s]: %s", timestamp, sample)

--- a/ads_async/asyncio/client.py
+++ b/ads_async/asyncio/client.py
@@ -25,8 +25,7 @@ class Notification(utils.CallbackHandler):
     it should be made by calling the ``add_notification()`` methods on
     the connection (or ``Symbol``).
     """
-    def __init__(self, owner, user_callback_executor,
-                 command, port):
+    def __init__(self, owner, user_callback_executor, command, port):
         super().__init__(notification_id=0, handle=None,
                          user_callback_executor=user_callback_executor)
         self.command = command
@@ -473,7 +472,18 @@ class AsyncioClient:
         #         ...
         #     # self._tasks.create()
 
-    def enable_log_system(self, length=255):
+    def enable_log_system(self, length=255) -> Notification:
+        """
+        Enable the logging system to get messages from the LOGGER port.
+
+        This returns a :class:`Notification` instance which can support an
+        arbitrary number of user-provided callback methods.
+
+        Parameters
+        ----------
+        length : int
+            Maximum length of each notification, in bytes.
+        """
         return self.add_notification_by_index(
             index_group=1,
             index_offset=65535,
@@ -490,7 +500,7 @@ class AsyncioClient:
         max_delay: int = 1,
         cycle_time: int = 100,
         port: Optional[AmsPort] = None,
-    ):
+    ) -> Notification:
         """
         Add an advanced notification by way of index group/offset.
 
@@ -503,7 +513,7 @@ class AsyncioClient:
             Contains the index offset number of the requested ADS service.
 
         length : int
-            Max length.
+            Maximum length of each notification, in bytes.
 
         mode : AdsTransmissionMode
             Specifies if the event should be fired cyclically or only if the

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -1157,6 +1157,10 @@ class AoEReadResponse(AoEResponseHeader):
         At the protocol level, clients are not currently able to determine
         the appropriate
         """
+        if self.result != constants.AdsError.NOERR:
+            # TODO: exception type
+            raise ValueError(f'Error response: {self.result.name}')
+
         if index_group == constants.AdsIndexGroup.SYM_INFOBYNAMEEX:
             return AdsSymbolEntry.deserialize(
                 memoryview(self._buffer)[AoEReadResponse._data_start.offset:]

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -412,7 +412,7 @@ class AdsDeviceInfo(AdsVersion):
         return (self.version, self.revision, self.build)
 
 
-class AdsNotificationAttrib(_AdsStructBase):
+class AdsNotificationAttrib(_AdsStructBase):  # TODO: Unused; may be removed?
     """
     Contains all the attributes for the definition of a notification.
 
@@ -1206,6 +1206,31 @@ class AoENotificationHandleResponse(AoEResponseHeader):
 def serialize_data(data_type: constants.AdsDataType, data: typing.Any,
                    length: int = None,
                    *, endian='<') -> typing.Tuple[int, bytes]:
+    """
+    Serialize symbol data for transmission over the wire.
+
+    Parameters
+    ----------
+    data_type : constants.AdsDataType
+        The data type of the data to serialize.
+
+    data :
+        The data to serialize.
+
+    length : int, optional
+        Number of elements of data_type (defaults to ``len(data)``).
+
+    endian: str, optional
+        Endianness of the stored data.  Defaults to little-endian.
+
+    Returns
+    -------
+    bytes_consumed : int
+        Number of bytes of the serialized data.
+
+    data : bytes
+        The serialized data.
+    """
     length = length if length is not None else len(data)
     ctypes_type = data_type.ctypes_type._type_  # type: ignore
     st = struct.Struct(f'{endian}{length}{ctypes_type}')
@@ -1216,6 +1241,31 @@ def deserialize_data(data_type: constants.AdsDataType,
                      length: int,
                      data: bytes,
                      *, endian='<') -> typing.Tuple[int, typing.Any]:
+    """
+    Deserialize symbol data from the wire.
+
+    Parameters
+    ----------
+    data_type : constants.AdsDataType
+        The data type of the data to deserialize.
+
+    data : bytes
+        The wire data to deserialize.
+
+    length : int, optional
+        Elements of data_type (defaults to ``len(data)``).
+
+    endian: str, optional
+        Endianness of the stored data.  Defaults to little-endian.
+
+    Returns
+    -------
+    bytes_consumed : int
+        Number of bytes consumed.
+
+    value :
+        The deserialized value.
+    """
     ctypes_type = data_type.ctypes_type._type_  # type: ignore
     st = struct.Struct(f'{endian}{length}{ctypes_type}')
     return st.size, st.unpack(data)

--- a/ads_async/tests/test_server.py
+++ b/ads_async/tests/test_server.py
@@ -134,7 +134,7 @@ def test_read_and_write_by_handle(
     request = structs.AdsReadRequest(
         constants.AdsIndexGroup.SYM_VALBYHND,
         handle,
-        length=symbol.size,
+        length=symbol.byte_size,
     )
 
     response, = send_request(client, command=request)
@@ -152,4 +152,4 @@ def test_read_symbol_info_ex(
     entry = response.data  # TODO: only because this is in the same process...
     assert isinstance(entry, structs.AdsSymbolEntry)
     assert entry.name == symbol.name
-    assert entry.type_name == symbol.data_type.name
+    assert entry.data_type == symbol.data_type

--- a/ads_async/tests/test_symbol.py
+++ b/ads_async/tests/test_symbol.py
@@ -27,7 +27,7 @@ def data_area(memory):
 
 
 def test_symbol(data_area):
-    sym = ads_async.symbols.SimpleSymbol(
+    sym = ads_async.symbols.BasicSymbol(
         data_area=data_area,
         name='test',
         offset=0,


### PR DESCRIPTION
* Enumerate task names in a dictionary of `{id: name}`
* Fix tests