### PR TITLE
FIX: argparser program reported 'ads' instead of 'ads-async'

### DIFF
--- a/ads_async/bin/ads_async.py
+++ b/ads_async/bin/ads_async.py
@@ -34,7 +34,7 @@ def _build_commands():
             unavailable.append((module, ex))
         else:
             result[module] = (mod.build_arg_parser, mod.main)
-            DESCRIPTION += f"\n    $ ads {module} --help"
+            DESCRIPTION += f"\n    $ ads-async {module} --help"
 
     if unavailable:
         DESCRIPTION += "\n\n"
@@ -53,7 +53,7 @@ COMMANDS = _build_commands()
 
 def main():
     top_parser = argparse.ArgumentParser(
-        prog="ads",
+        prog="ads-async",
         description=DESCRIPTION,
         formatter_class=argparse.RawTextHelpFormatter,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Closes #25 

## How Has This Been Tested?
Verified in console:

```
(ads-async) PC98125:ads-async klauer$ ads-async --help
usage: ads-async [-h] [--version] [--log LOG_LEVEL] {get,info,monitor,route} ...

`ads-async` is the top-level command for accessing various subcommands.

Try::

    $ ads-async get --help
    $ ads-async info --help
    $ ads-async monitor --help
    $ ads-async route --help

positional arguments:
  {get,info,monitor,route}
                        Possible subcommands

optional arguments:
  -h, --help            show this help message and exit
  --version, -V         Show the ads-async version number and exit.
  --log LOG_LEVEL, -l LOG_LEVEL
                        Python logging level (e.g. DEBUG, INFO, WARNING)
```