### PR TITLE
BLD: remove versioneer requirement, as we vendor it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-versioneer


### PR DESCRIPTION
* Remove versioneer

No main requirements for this project, then, just standard Python. Leaving `requirements.txt` regardless for future purposes.