### PR TITLE
FIX: clients can read with index group + offset directly

### DIFF
--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -1324,7 +1324,7 @@ class ServerCircuit(_Circuit):
             flags=constants.AdsSymbolFlag(0),  # TODO symbol.flags
             name=symbol.name,
             type_name=symbol.data_type_name,
-            comment=symbol.__doc__ or "",
+            comment=symbol.comment or "",
         )
         return [structs.AoEReadResponse(data=symbol_entry)]
 

--- a/ads_async/protocol.py
+++ b/ads_async/protocol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import ctypes
 import inspect
@@ -306,7 +308,7 @@ class _Connection:
     _our_address: IPPort
     _our_net_id: str
     circuit_class: type
-    circuits: Dict[str, "_Circuit"]
+    circuits: Dict[str, _Circuit]
     recv_buffer: bytearray
     role: Role
     their_address: IPPort
@@ -372,7 +374,7 @@ class _Connection:
             self.recv_buffer = self.recv_buffer[consumed:]
             yield item
 
-    def get_circuit(self, net_id: Union[AmsNetId, str]) -> "_Circuit":
+    def get_circuit(self, net_id: Union[AmsNetId, str]) -> _Circuit:
         """Get a circuit for (their) Net ID."""
         if isinstance(net_id, AmsNetId):
             net_id = repr(net_id)

--- a/ads_async/structs.py
+++ b/ads_async/structs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import enum
 import functools
@@ -484,7 +486,7 @@ class AdsNotificationLogMessage(_AdsStructBase):
     @classmethod
     def deserialize(
         cls: typing.Type[T_AdsStructure], buf: typing.Union[memoryview, bytearray]
-    ) -> "AdsNotificationLogMessage":
+    ) -> AdsNotificationLogMessage:
         """Deserialize a log message."""
         # message_length is not reliable when nearing 255+ characters!
         new_struct = cls.from_buffer(buf)
@@ -862,7 +864,7 @@ class AdsReadWriteRequest(_AdsStructBase):
     _dict_mapping = {"_index_group": "index_group"}
 
     @classmethod
-    def create_handle_by_name_request(cls, name: str) -> "AdsReadWriteRequest":
+    def create_handle_by_name_request(cls, name: str) -> AdsReadWriteRequest:
         data = string_to_byte_string(name) + b"\x00"
         request = cls(
             constants.AdsIndexGroup.SYM_HNDBYNAME,
@@ -874,7 +876,7 @@ class AdsReadWriteRequest(_AdsStructBase):
         return request
 
     @classmethod
-    def create_info_by_name_request(cls, name: str) -> "AdsReadWriteRequest":
+    def create_info_by_name_request(cls, name: str) -> AdsReadWriteRequest:
         # Read length includes up to 3 T_MaxString strings:
         read_length = ctypes.sizeof(AdsSymbolEntry) + 3 * 256
 
@@ -939,7 +941,7 @@ class AoERequestHeader(_AdsStructBase):
     @classmethod
     def from_sdo(
         cls, sdo_index: int, sdo_sub_index: int, data_length: int
-    ) -> "AoERequestHeader":
+    ) -> AoERequestHeader:
         """
         Create an AoERequestHeader given SDO settings.
 
@@ -1077,7 +1079,7 @@ class AoEHeader(_AdsStructBase):
         *,
         state_flags: constants.AoEHeaderFlag = AoEHeaderFlag.ADS_COMMAND,
         error_code: int = 0,
-    ) -> "AoEHeader":
+    ) -> AoEHeader:
         """Create a request header."""
         return cls(
             target, source, command_id, state_flags, length, error_code, invoke_id
@@ -1096,7 +1098,7 @@ class AoEHeader(_AdsStructBase):
             AoEHeaderFlag.ADS_COMMAND | AoEHeaderFlag.RESPONSE
         ),
         error_code: int = 0,
-    ) -> "AoEHeader":
+    ) -> AoEHeader:
         """Create a response header."""
         return cls(
             target, source, command_id, state_flags, length, error_code, invoke_id
@@ -1157,7 +1159,7 @@ class AoEReadResponse(AoEResponseHeader):
 
     def upcast_by_index_group(
         self, index_group: constants.AdsIndexGroup
-    ) -> "AoEHandleResponse":
+    ) -> AoEHandleResponse:
         """
         Cast the data payload into an appropriate structure.
 
@@ -1178,7 +1180,7 @@ class AoEReadResponse(AoEResponseHeader):
             )
         return self
 
-    def as_handle_response(self) -> "AoEHandleResponse":
+    def as_handle_response(self) -> AoEHandleResponse:
         return AoEHandleResponse.deserialize(self._buffer)
 
 

--- a/ads_async/symbols.py
+++ b/ads_async/symbols.py
@@ -5,6 +5,7 @@ import math
 import sys
 import textwrap
 import typing
+from typing import Optional
 
 from . import constants, log, structs
 from .constants import AdsDataType
@@ -85,9 +86,10 @@ class Symbol:
         data_type: constants.AdsDataType,
         array_length: int,
         data_area: "DataArea",
-        type_name: str = None,
-        bit_offset: int = None,
+        type_name: Optional[str] = None,
+        bit_offset: Optional[int] = None,
         pointer: bool = False,
+        comment: Optional[str] = None,
     ):
         self.array_length = array_length
         self.data_area = data_area
@@ -97,6 +99,7 @@ class Symbol:
         self.offset = offset
         self.bit_offset = bit_offset
         self.pointer = pointer  # TODO: only depth of 1
+        self.comment = comment or ""
         self.log = log.ComposableLogAdapter(
             module_logger,
             extra=dict(
@@ -231,9 +234,8 @@ def tmc_to_symbols(
             bit_offset=bit_offset_obj,
             pointer=pointer,
             type_name=data_type.name,
+            comment=(item.Comment[0].text if hasattr(item, "Comment") else ""),
         )
-        if hasattr(item, "Comment"):
-            symbol.__doc__ = item.Comment[0].text
 
         yield symbol
     else:
@@ -486,6 +488,50 @@ class TmcDatabase(Database):
         self.add_data_area(
             index_group, DataArea(index_group, "PLC_MEMORY_AREA", memory_size=100_000)
         )
+
+
+class SimpleDatabase(Database):
+    _last_symbol: Optional[Symbol]
+
+    def __init__(self, memory_size=16_000_000):
+        super().__init__()
+
+        self.data_area = DataArea(
+            index_group=constants.AdsIndexGroup.PLC_DATA_AREA,
+            area_type="dynamic",
+            memory_size=memory_size,
+        )
+        self.index_groups = {
+            constants.AdsIndexGroup.PLC_DATA_AREA: self.data_area,
+        }
+        self._last_symbol = None
+
+    def add_basic_symbol(
+        self,
+        name: str,
+        data_type: AdsDataType,
+        array_length: int = 1,
+        comment: Optional[str] = None,
+    ) -> BasicSymbol:
+        """Add a basic (non-struct) symbol."""
+        if self._last_symbol is None:
+            offset = 1000
+        else:
+            offset = self._last_symbol.memory_range[1] + 1
+
+        sym = BasicSymbol(
+            name=name,
+            offset=offset,
+            data_type=data_type,
+            data_area=self.data_area,
+            array_length=array_length,
+            comment=comment,
+        )
+        self.data_area.symbols[name] = sym
+        return sym
+
+    def get_symbol_by_name(self, symbol_name: str) -> Symbol:
+        return self.data_area.symbols[symbol_name]
 
 
 def map_symbols_in_memory(

--- a/ads_async/symbols.py
+++ b/ads_async/symbols.py
@@ -391,7 +391,7 @@ class TmcTypes(enum.Enum):
     ITComObjectServer = AdsDataType.UINT64  # TODO: 32 on 32-bit machines...
 
 
-class DataAreaIndexGroup(enum.Enum):
+class DataAreaIndexGroup(enum.IntEnum):
     # <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
     # e.g., Global_Version.stLibVersion_Tc2_System
     Internal = constants.AdsIndexGroup.PLC_DATA_AREA  # 0x4040


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Fix when clients try to use index group + offset directly

## Motivation and Context
* Tried to use an `ADSREAD` function block from a PLC to get data from an ads-async server
* With the change to `IntEnum`, allowing the server to properly key on the index group integer, it was successful

## How Has This Been Tested?

```
PROGRAM MAIN
VAR
	fbAdsRead : Tc2_System.ADSREAD;
	sNetId : T_AmsNetID := '';
	nPort : T_AmsPort := 851;
	bRead : BOOL;
	iRead : INT;
	iIdx : INT;

END_VAR


...

fbAdsRead(
	NETID:=sNetId,
	PORT:=nPort,
	IDXGRP:=16448,
	IDXOFFS:=677976,
	LEN:=1,
	DESTADDR:=ADR(iRead),
	READ:=bRead,
);

```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
