### PR TITLE
BLD/FIX: set package name appropriately for conda

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set package_name = "ads_async" %}
+{% set package_name = "ads-async" %}
 {% set import_name = "ads_async" %}
 {% set version = load_file_regex(load_file=os.path.join(import_name, "_version.py"), regex_pattern=".*version = '(\S+)'").group(1) %}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* `ads-async` not `ads_async`
* Related to https://github.com/pcdshub/hutch-python/pull/367

## Motivation and Context
Let's upload the correctly-named package to our pcds-tag conda.