### PR TITLE
FIX/ENH: local mode based on nodejs implementation

### DIFF
--- a/ads_async/exceptions.py
+++ b/ads_async/exceptions.py
@@ -8,6 +8,10 @@ class AdsAsyncException(Exception):
     ...
 
 
+class AdsPortRequestFailureException(Exception):
+    ...
+
+
 class DisconnectedError(Exception):
     """TCP/IP disconnection."""
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Enable client communication with the ADS server running on localhost for TwinCAT BSD systems.

## Motivation and Context
* Communication with a local ADS server (i.e., on `localhost`) requires that you reserve a port from the router (and hopefully release it when you're done)
* I may be wrong, but it does not appear that this is implemented in Beckhoff's reference implementation
* I think the author of a nodejs ADS client figured this out, which is the reference implementation for this fix: https://github.com/jisotalo/ads-client/ (this has since been at least partially propagated to the rust client ads-rs though I'm not sure if it cleared it after use)
  * nodejs reference: [registration](https://github.com/jisotalo/ads-server/blob/c9d09d6af4e4137aa555b4bd9ba2c18d4ce55a81/src/ads-server-router.ts#L484-L575), [unregistration](https://github.com/jisotalo/ads-server/blob/c9d09d6af4e4137aa555b4bd9ba2c18d4ce55a81/src/ads-server-router.ts#L580-L650)
  * Rust reference: https://github.com/birkenfeld/ads-rs/blob/7d4ca8a81f86e2fac14432c39df9ec20d352ab99/src/client.rs#L219-L230 
  * Beckhoff/ADS reference: ? (*)

(*) If we want to get ads-ioc working on TwinCAT/BSD through [linuxemu](https://docs.freebsd.org/en/books/handbook/linuxemu/) we're going to have to replicate this there somehow. 

## How Has This Been Tested?
* Only briefly on a TcBSD VM

## Where Has This Been Documented?
This PR

## Screenshots (if appropriate):

```
[TCBSD: RUN] [Administrator@test-plc-01  ~]$ ~/.local/bin/ads-async --log DEBUG get --our-net-id 127.0.0.1.1.1 --net-id 192.168.2.193.1.1 127.0.0.1  MAIN.iCount
DEBUG:ads_async:main(**{'host': '127.0.0.1', 'symbols': ['MAIN.iCount'], 'net_id': '192.168.2.193.1.1', 'add_route': False, 'our_net_id': '127.0.0.1.1.1', 'our_host': '127.0.0.1', 'timeout': 2.0})
DEBUG:ads_async.protocol:Connecting...
DEBUG:ads_async.protocol:Connected
DEBUG:ads_async.protocol:Reserved local connection settings from router: 192.168.2.193.1.1 (port=15945)
DEBUG:ads_async.protocol:AmsTcpHeader(reserved=0, length=60)
DEBUG:ads_async.protocol:AoEHeader(target=192.168.2.193.1.1:851(R0_PLC_TC3), source=192.168.2.193.1.1:32997, command_id=<AdsCommandId.READ_WRITE: 9>, state_flags=<AoEHeaderFlag.ADS_COMMAND: 4>, length=28, error_code=0, invoke_id=101)
DEBUG:ads_async.protocol:AdsReadWriteRequest(index_group=<AdsIndexGroup.SYM_INFOBYNAMEEX: 61449>, index_offset=0, read_length=798, write_length=12, data=b'MAIN.iCount\x00')
DEBUG:ads_async.protocol:(AoEHeader(target=192.168.2.193.1.1:32997, source=192.168.2.193.1.1:851(R0_PLC_TC3), command_id=<AdsCommandId.READ_WRITE: 9>, state_flags=<AoEHeaderFlag.ADS_COMMAND|RESPONSE: 5>, length=104, error_code=0, invoke_id=101), AoEReadResponse(result=<AdsError.NOERR: 0>, read_length=96, data=b'`\x00\x00\x00@@\x00\x00\xf2\xdf\x05\x00\x02\x00\x00\x00\x02\x00\x00\x00\x08\x10\x00\x00\x0b\x00\x03\x00\x00\x00MAIN.iCount\x00INT\x00\x00\x95\x19\x07\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06\x01\x00\x05\x13pytmc\x00pv: PLC:TEST:iCount\x00\x00\x00\x00'))
DEBUG:ads_async.protocol:Handling AoEReadResponse(result=<AdsError.NOERR: 0>, read_length=96, data=b'`\x00\x00\x00@@\x00\x00\xf2\xdf\x05\x00\x02\x00\x00\x00\x02\x00\x00\x00\x08\x10\x00\x00\x0b\x00\x03\x00\x00\x00MAIN.iCount\x00INT\x00\x00\x95\x19\x07\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06\x01\x00\x05\x13pytmc\x00pv: PLC:TEST:iCount\x00\x00\x00\x00')
DEBUG:ads_async.protocol:AmsTcpHeader(reserved=0, length=60)
DEBUG:ads_async.protocol:AoEHeader(target=192.168.2.193.1.1:851(R0_PLC_TC3), source=192.168.2.193.1.1:32997, command_id=<AdsCommandId.READ_WRITE: 9>, state_flags=<AoEHeaderFlag.ADS_COMMAND: 4>, length=28, error_code=0, invoke_id=102)
DEBUG:ads_async.protocol:AdsReadWriteRequest(index_group=<AdsIndexGroup.SYM_HNDBYNAME: 61443>, index_offset=0, read_length=4, write_length=12, data=b'MAIN.iCount\x00')
DEBUG:ads_async.protocol:(AoEHeader(target=192.168.2.193.1.1:32997, source=192.168.2.193.1.1:851(R0_PLC_TC3), command_id=<AdsCommandId.READ_WRITE: 9>, state_flags=<AoEHeaderFlag.ADS_COMMAND|RESPONSE: 5>, length=12, error_code=0, invoke_id=102), AoEReadResponse(result=<AdsError.NOERR: 0>, read_length=4, data=b'\x0e\x00\x00\x01'))
DEBUG:ads_async.protocol:Handling AoEReadResponse(result=<AdsError.NOERR: 0>, read_length=4, data=b'\x0e\x00\x00\x01')
DEBUG:ads_async.protocol:AmsTcpHeader(reserved=0, length=44)
DEBUG:ads_async.protocol:AoEHeader(target=192.168.2.193.1.1:851(R0_PLC_TC3), source=192.168.2.193.1.1:32997, command_id=<AdsCommandId.READ: 2>, state_flags=<AoEHeaderFlag.ADS_COMMAND: 4>, length=12, error_code=0, invoke_id=103)
DEBUG:ads_async.protocol:AdsReadRequest(index_group=<AdsIndexGroup.SYM_VALBYHND: 61445>, index_offset=16777230, length=2)
DEBUG:ads_async.protocol:(AoEHeader(target=192.168.2.193.1.1:32997, source=192.168.2.193.1.1:851(R0_PLC_TC3), command_id=<AdsCommandId.READ: 2>, state_flags=<AoEHeaderFlag.ADS_COMMAND|RESPONSE: 5>, length=10, error_code=0, invoke_id=103), AoEReadResponse(result=<AdsError.NOERR: 0>, read_length=2, data=b'\xc5w'))
DEBUG:ads_async.protocol:Handling AoEReadResponse(result=<AdsError.NOERR: 0>, read_length=2, data=b'\xc5w')
DEBUG:ads_async.protocol:AmsTcpHeader(reserved=0, length=44)
DEBUG:ads_async.protocol:AoEHeader(target=192.168.2.193.1.1:851(R0_PLC_TC3), source=192.168.2.193.1.1:32997, command_id=<AdsCommandId.WRITE: 3>, state_flags=<AoEHeaderFlag.ADS_COMMAND: 4>, length=12, error_code=0, invoke_id=104)
DEBUG:ads_async.protocol:AdsWriteRequest(index_group=<AdsIndexGroup.SYM_RELEASEHND: 61446>, index_offset=16777230, write_length=0, data=b'')
{
    "MAIN.iCount": [
        30661
    ]
}
```